### PR TITLE
feat: add business type selection to onboarding flow

### DIFF
--- a/src/app/onboarding/type-of-business/error.tsx
+++ b/src/app/onboarding/type-of-business/error.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { RefreshCw } from "lucide-react";
+import Link from "next/link";
+import { useEffect } from "react";
+
+export default function TypeOfBusinessError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Type of Business Error:", error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Header Navigation */}
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="mt-6 flex items-center justify-end gap-x-6">
+          <Button variant="outline" disabled>
+            Begin Onboarding
+          </Button>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className="mx-auto max-w-2xl px-4 sm:px-6 lg:px-8">
+        <div className="flex min-h-[calc(100vh-200px)] items-center justify-center">
+          <div className="text-center space-y-12">
+            {/* Error Message */}
+            <div className="space-y-6">
+              <div className="space-y-2">
+                <p className="text-sm text-muted-foreground">Business Type</p>
+                <h1 className="text-4xl font-light text-destructive tracking-tight">
+                  Something went wrong
+                </h1>
+              </div>
+              <p className="text-lg text-destructive max-w-md mx-auto leading-relaxed">
+                We are having trouble loading the business type selection.
+                This is usually temporary.
+              </p>
+            </div>
+
+            {/* Action Buttons */}
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Button
+                onClick={reset}
+                size="lg"
+                className="min-w-32"
+                variant="outline"
+              >
+                <RefreshCw className="w-4 h-4 mr-2" />
+                Try Again
+              </Button>
+            </div>
+
+            {/* Help Link */}
+            <div className="pt-8">
+              <p className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+                You can contact support if this issue continues by clicking
+                <Button asChild variant="link" className="py-0 pl-1">
+                  <Link
+                    href={`mailto:support@easeandarrange.com?subject=Business Type Selection Issue&body=I encountered an error while selecting my business type. Error ID: ${error.digest || "N/A"}`}
+                  >
+                    here
+                  </Link>
+                </Button>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/onboarding/type-of-business/loading.tsx
+++ b/src/app/onboarding/type-of-business/loading.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function TypeOfBusinessLoading() {
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Header Navigation */}
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="mt-6 flex items-center justify-end gap-x-6">
+          <Skeleton className="h-8 w-8 rounded-full" />
+          <Skeleton className="h-10 w-40" />
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+        <div className="pb-12">
+          <Skeleton className="h-4 w-24 mb-2" />
+          <Skeleton className="h-8 w-56 mt-2" />
+          <Skeleton className="h-4 w-96 mt-2 max-w-full" />
+        </div>
+
+        <div>
+          <div className="space-y-12 max-w-4xl">
+            <div className="border-b border-border pb-12">
+              <div className="mt-10 space-y-6">
+                {/* Business Type Options */}
+                <div className="space-y-4">
+                  <Skeleton className="h-16 w-full rounded-lg" />
+                  <Skeleton className="h-16 w-full rounded-lg" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/onboarding/type-of-business/page.tsx
+++ b/src/app/onboarding/type-of-business/page.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { ArrowRight, Building2, User } from "lucide-react";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { SignedIn, UserButton } from "@clerk/nextjs";
+
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+export default function TypeOfBusinessPage() {
+  return (
+    <div>
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="mt-6 flex items-center justify-end gap-x-6">
+          <SignedIn>
+            <UserButton />
+          </SignedIn>
+          <Button variant="outline" disabled>
+            Continue
+          </Button>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+        <div className="pb-12">
+          <span className="mt-2 text-sm text-muted-foreground">
+            Business Type
+          </span>
+          <h2 className="mt-2 text-3xl font-semibold text-foreground">
+            What type of business entity are you?
+          </h2>
+          <p className="mt-2 max-w-4xl text-sm text-foreground">
+            Let us know how you operate so we can customize your experience and
+            tax information accordingly.
+          </p>
+        </div>
+
+        <div>
+          <div className="space-y-12 max-w-4xl">
+            <div className="border-b border-border pb-12">
+              <div className="mt-10 space-y-6">
+                <div className="grid gap-4 md:grid-cols-2">
+                  {/* Freelancer Option */}
+                  <Card className="cursor-pointer transition-all hover:shadow-md hover:border-foreground/25">
+                    <Link
+                      href="/onboarding/basic-info"
+                      className="block h-full"
+                    >
+                      <CardHeader className="text-center space-y-4">
+                        <div className="mx-auto size-12 rounded-full bg-primary/10 flex items-center justify-center">
+                          <User className="size-6 text-primary" />
+                        </div>
+                        <div className="space-y-2">
+                          <CardTitle className="text-lg">Freelancer</CardTitle>
+                          <CardDescription className="text-sm">
+                            Just me, no registered business entity
+                          </CardDescription>
+                        </div>
+                        <div className="flex items-center justify-center text-primary">
+                          <span className="text-sm font-medium mr-2">
+                            Continue as individual
+                          </span>
+                          <ArrowRight className="size-4" />
+                        </div>
+                      </CardHeader>
+                    </Link>
+                  </Card>
+
+                  {/* Business Option */}
+                  <Card className="cursor-pointer transition-all hover:shadow-md hover:border-foreground/25">
+                    <Link
+                      href="/onboarding/business-info"
+                      className="block h-full"
+                    >
+                      <CardHeader className="text-center space-y-4">
+                        <div className="mx-auto size-12 rounded-full bg-primary/10 flex items-center justify-center">
+                          <Building2 className="size-6 text-primary" />
+                        </div>
+                        <div className="space-y-2">
+                          <CardTitle className="text-lg">
+                            Yes, I have a business
+                          </CardTitle>
+                          <CardDescription className="text-sm">
+                            e.g. LLC, Sole Proprietorship, Partnership
+                          </CardDescription>
+                        </div>
+                        <div className="flex items-center justify-center text-primary">
+                          <span className="text-sm font-medium mr-2">
+                            Continue as business
+                          </span>
+                          <ArrowRight className="size-4" />
+                        </div>
+                      </CardHeader>
+                    </Link>
+                  </Card>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/onboarding/welcome/page.tsx
+++ b/src/app/onboarding/welcome/page.tsx
@@ -15,7 +15,7 @@ async function handleBeginOnboarding() {
     notFound();
   }
 
-  redirect("/onboarding/basic-info");
+  redirect("/onboarding/type-of-business");
 }
 
 export default function OnboardingWelcomePage() {


### PR DESCRIPTION
## Summary
- Add new `/onboarding/type-of-business` step with business entity selection
- Two options: freelancer (individual) or registered business entity
- Route freelancers to `basic-info`, business entities to `business-info` 
- Update welcome page redirect to include business type selection
- Follow consistent onboarding page patterns and styling

## Test plan
- [ ] Navigate to `/onboarding/type-of-business` and verify page loads
- [ ] Click freelancer option and verify redirect to `/onboarding/basic-info`
- [ ] Click business option and verify redirect to `/onboarding/business-info`
- [ ] Verify error and loading states display correctly
- [ ] Test responsive design on mobile and desktop

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a business type selection step in the onboarding process, allowing users to choose between freelancer and registered business options.
  * Added a loading skeleton screen for the business type selection page to enhance user experience during data fetching.
  * Implemented an error display with retry and support contact options for issues encountered during business type selection.

* **Chores**
  * Updated onboarding flow to redirect users to the new business type selection step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->